### PR TITLE
Define dynamic object handlers for @nestjs/microservices

### DIFF
--- a/src/util/dynamic.object.handler.factory.ts
+++ b/src/util/dynamic.object.handler.factory.ts
@@ -18,7 +18,7 @@ export function createDynamicObjectHandler<T extends object>(instanceResolver: (
             return instanceResolver()[p];
         },
         getOwnPropertyDescriptor(target: T, p: string | symbol): PropertyDescriptor | undefined {
-            throw new NotImplementedException();
+            return Object.getOwnPropertyDescriptor(instanceResolver(), p);
         },
         getPrototypeOf(target: T): object | null {
             return Object.getPrototypeOf(instanceResolver());
@@ -30,7 +30,7 @@ export function createDynamicObjectHandler<T extends object>(instanceResolver: (
             throw new NotImplementedException();
         },
         ownKeys(target: T): ArrayLike<string | symbol> {
-            throw new NotImplementedException();
+            return Object.keys(instanceResolver());
         },
         preventExtensions(target: T): boolean {
             throw new NotImplementedException();


### PR DESCRIPTION
These functions are required for this module to work correctly when using @nestjs/microservices.

For context -- we are adding a gRPC microservices to an existing nest application. We do not want to try to use a separate microservice and modules for this implementation.